### PR TITLE
make token accounts task more flexible and let init_transaction_hash be nullable

### DIFF
--- a/migrations/20220504233510_create_tbc_accounts_table.ts
+++ b/migrations/20220504233510_create_tbc_accounts_table.ts
@@ -3,7 +3,7 @@ import { Knex } from "knex";
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.createTable("tbc_accounts", function (table) {
     table.increments();
-    table.binary("init_transaction_hash", 64).notNullable().unique();
+    table.binary("init_transaction_hash", 64).unique();
 
     table.binary("token_a_account_address", 32).notNullable().unique();
     table.binary("token_a_account_owner_address", 32).notNullable();

--- a/scripts/add_tbc_account.ts
+++ b/scripts/add_tbc_account.ts
@@ -1,19 +1,26 @@
 import { getKnex, closeKnexConnection } from "../src/database";
 import { PublicKey } from "@solana/web3.js";
-import { TBCAccount, TBCTokenMint } from "../src/knex-types/tbc_accounts";
+import { TBCAccount } from "../src/knex-types/tbc_account";
+import { TBCTokenMint } from "../src/knex-types/tbc_token_mint";
 import bs58 from "bs58";
 
 /** Inserts new row to tbc_accounts
  *
- * arg 1 is init_transaction_hash: the txn hash that this TBC was initialized in
+ * arg 1 is init_transaction_hash: the txn hash that this TBC was initialized in ("null" if it's just a 
+ * random token account to track and not part of a TBC, e.g. a liquidity pool)
  * arg 2 is token_a_account_address: pubkey of the token_a_account_address
  * arg 3 is token_a_account_owner_address: pubkey of the owner of token_a_account_address
  * arg 4 is token_a_mint_address: mint address of token A (usually sRLY)
  *
  * e.g. $ npm run add-tbc-account \
- 66tnH1qyBeNMWsGf5ZZUijK14RbzQ9JJ8ZUP15ayrGXMTAQnYPe4S7jhBZ1joHRpBib2khjweTiTXJUs1NfVuGqr \
- 4Fce62WKxUeBrR7ShrxjC4WL6gcyeTEUyByCdFufBQuC Eh9mq1m2X2MgiZGd2hfMEbAuKZcbdXTo7EqFUcT9EyVS \
- RLYv2ubRMDLcGG2UyvPmnPmkfuQTsMbg4Jtygc7dmnq
+    66tnH1qyBeNMWsGf5ZZUijK14RbzQ9JJ8ZUP15ayrGXMTAQnYPe4S7jhBZ1joHRpBib2khjweTiTXJUs1NfVuGqr \
+    4Fce62WKxUeBrR7ShrxjC4WL6gcyeTEUyByCdFufBQuC Eh9mq1m2X2MgiZGd2hfMEbAuKZcbdXTo7EqFUcT9EyVS \
+    RLYv2ubRMDLcGG2UyvPmnPmkfuQTsMbg4Jtygc7dmnq
+
+ * e.g. $ npm run add-tbc-account \
+    nullr \
+    4Fce62WKxUeBrR7ShrxjC4WL6gcyeTEUyByCdFufBQuC Eh9mq1m2X2MgiZGd2hfMEbAuKZcbdXTo7EqFUcT9EyVS \
+    RLYv2ubRMDLcGG2UyvPmnPmkfuQTsMbg4Jtygc7dmnq
  */
 const main = async () => {
   const knex = getKnex();
@@ -25,9 +32,14 @@ const main = async () => {
 
   // validate keys and convert to byte array to store in DB
 
-  const initTransactionHash = bs58.decode(initTransactionHashString!);
-  if (initTransactionHash.length != 64) {
-    throw new Error(`Invalid transaction hash`);
+  let initTransactionHash: Uint8Array | undefined;
+  if (initTransactionHashString === "null") {
+    initTransactionHash = undefined;
+  } else {
+    initTransactionHash = bs58.decode(initTransactionHashString!);
+    if (initTransactionHash.length != 64) {
+      throw new Error(`Invalid transaction hash`);
+    }
   }
 
   const tokenAAccountAddress = new PublicKey(

--- a/scripts/add_tbc_token_mint.ts
+++ b/scripts/add_tbc_token_mint.ts
@@ -1,6 +1,6 @@
 import { getKnex, closeKnexConnection } from "../src/database";
 import { PublicKey } from "@solana/web3.js";
-import { TBCTokenMint } from "../src/knex-types/tbc_accounts";
+import { TBCTokenMint } from "../src/knex-types/tbc_token_mint";
 
 /** Inserts new row to tbc_token_mints
  *

--- a/scripts/get_token_accounts_info.ts
+++ b/scripts/get_token_accounts_info.ts
@@ -5,13 +5,20 @@ import { getAllTokenAccountInfoAndTransactionsForEndDate } from "../src/token_ac
  * 00:00 UTC for consistency (i.e. you can't pass a specific time, only dates)
  *
  * arg 1 is the endDate
+ * arg 2 is forceOneDay flag (default false). if true, will get 24 hours of data instead of getting data from
+ * the previously fetched end date
  *
  * e.g. $ npm run get-token-accounts-info 2022-05-05
+ * e.g. $ npm run get-token-accounts-info 2022-05-05 true
  */
 const main = async () => {
   const endDateString = process.argv[2];
+  const forceOneDay = process.argv[3] === "true";
 
-  await getAllTokenAccountInfoAndTransactionsForEndDate(endDateString!);
+  await getAllTokenAccountInfoAndTransactionsForEndDate(
+    endDateString!,
+    forceOneDay
+  );
 
   closeKnexConnection();
 };

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -13,7 +13,8 @@ export function initCron() {
       latestEndDate.toISOString().substring(0, 10)
     );
     await getAllTokenAccountInfoAndTransactionsForEndDate(
-      latestEndDate.toISOString().substring(0, 10)
+      latestEndDate.toISOString().substring(0, 10),
+      false
     );
   });
 }

--- a/src/knex-types/tbc_account.ts
+++ b/src/knex-types/tbc_account.ts
@@ -1,6 +1,6 @@
 export interface TBCAccount {
   id?: number;
-  init_transaction_hash: Uint8Array;
+  init_transaction_hash?: Uint8Array;
   token_a_account_address: Uint8Array;
   token_a_account_owner_address: Uint8Array;
   token_a_mint_id: number;


### PR DESCRIPTION
getAllTokenAccountInfoAndTransactionsForEndDate fetches from the last
successfully fetched date instead of just 24 hours (with a flag to
force a 24 fetch in case a day needs to be re-run)