### PR TITLE
Allow all CORs requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^17.0.31",
         "@types/node-cron": "^3.0.1",
         "bs58": "^5.0.0",
+        "cors": "^2.8.5",
         "cross-fetch": "^3.1.5",
         "dotenv": "^16.0.0",
         "express": "^4.18.1",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.1",
+        "@types/cors": "^2.8.12",
         "@types/mocha": "^9.1.1",
         "@types/supertest": "^2.0.12",
         "chai": "^4.3.6",
@@ -338,6 +340,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
+      "dev": true
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
     "node_modules/@types/express": {
@@ -1181,6 +1189,18 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2973,6 +2993,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -4751,6 +4779,12 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -5385,6 +5419,15 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
       "dev": true
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-require": {
       "version": "1.1.1",
@@ -6644,6 +6687,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^17.0.31",
     "@types/node-cron": "^3.0.1",
     "bs58": "^5.0.0",
+    "cors": "^2.8.5",
     "cross-fetch": "^3.1.5",
     "dotenv": "^16.0.0",
     "express": "^4.18.1",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
+    "@types/cors": "^2.8.12",
     "@types/mocha": "^9.1.1",
     "@types/supertest": "^2.0.12",
     "chai": "^4.3.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import routes from "./routes";
 import { initCron } from "./cron";
+import cors from "cors";
 
 class App {
   public server;
@@ -15,6 +16,7 @@ class App {
   }
 
   middlewares() {
+    this.server.use(cors());
     this.server.use(express.json());
   }
 


### PR DESCRIPTION
Couple good reasons to do this: 1. We want an open API that others could
build on top of, 2. our own rewards UI is going to be on another domain.

Adds express cors package to do the CORs stuff with basically no code on
our part
