### PR TITLE
Add by day support for existing computed metrics

### DIFF
--- a/src/computed_metrics/wallet_metrics.ts
+++ b/src/computed_metrics/wallet_metrics.ts
@@ -26,3 +26,21 @@ export async function totalWallets(
 
   return result[0]?.count;
 }
+
+export async function totalWalletsByDay(trackedTokens: TrackedToken[]) {
+  const startDateFilter = new Date(0);
+
+  const dbResponse: { datetime: Date; count: string }[] = await knex
+    .from("tracked_token_account_balances")
+    .select("datetime")
+    .countDistinct("tracked_token_account_id")
+    .where("datetime", ">=", startDateFilter)
+    .whereIn("tracked_token_account_id", accountIdsForTokens(trackedTokens))
+    .groupBy("datetime")
+    .orderBy("datetime");
+
+  return dbResponse.map((record) => ({
+    date: record.datetime.toISOString(),
+    walletCount: parseInt(record.count),
+  }));
+}

--- a/tests/computed_metrics/total_value_locked.test.ts
+++ b/tests/computed_metrics/total_value_locked.test.ts
@@ -3,12 +3,15 @@ import { LiquidityPool } from "../../src/knex-types/liquidity_pool";
 import { LiquidityPoolBalance } from "../../src/knex-types/liquidity_pool_balance";
 import { LiquidityCollateralToken } from "../../src/knex-types/liquidity_collateral_token";
 import { createLiquidityCollateralToken } from "../factories";
-import { totalValueLockedInPools } from "../../src/computed_metrics/total_value_locked";
+import {
+  valueLockedByDay,
+  totalValueLockedInPools,
+} from "../../src/computed_metrics/total_value_locked";
 import { expect } from "chai";
 
 const knex = getKnex();
 
-describe("#totalValueLockedInPools", () => {
+describe("Total Value Locked Computed Metrics", () => {
   let collaterToken1: LiquidityCollateralToken;
   let collaterToken2: LiquidityCollateralToken;
   let pool1: LiquidityPool;
@@ -36,61 +39,125 @@ describe("#totalValueLockedInPools", () => {
       "*"
     );
   });
-  it("returns the total sum of the most recent balance for all pools with the given collateral tokens", async () => {
-    await knex<LiquidityPoolBalance>("liquidity_pool_balances").insert([
-      {
-        balance: 10,
-        liquidity_pool_id: pool1.id,
-        datetime: new Date("2022-05-20"),
-      },
-      {
-        balance: 5,
-        liquidity_pool_id: pool1.id,
-        datetime: new Date("2022-05-19"),
-      },
-      {
-        balance: 25,
-        liquidity_pool_id: pool2.id,
-        datetime: new Date("2022-05-19"),
-      },
-    ]);
 
-    expect(
-      await totalValueLockedInPools([collaterToken1, collaterToken2])
-    ).to.equal("35");
+  describe("#totalValueLockedInPools", () => {
+    it("returns the total sum of the most recent balance for all pools with the given collateral tokens", async () => {
+      await knex<LiquidityPoolBalance>("liquidity_pool_balances").insert([
+        {
+          balance: 10,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-20"),
+        },
+        {
+          balance: 5,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-19"),
+        },
+        {
+          balance: 25,
+          liquidity_pool_id: pool2.id,
+          datetime: new Date("2022-05-19"),
+        },
+      ]);
+
+      expect(
+        await totalValueLockedInPools([collaterToken1, collaterToken2])
+      ).to.equal("35");
+    });
+
+    it("can ignore balances for collateral tokens we don't care about ", async () => {
+      await knex<LiquidityPoolBalance>("liquidity_pool_balances").insert([
+        {
+          balance: 10,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-20"),
+        },
+        {
+          balance: 5,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-19"),
+        },
+        {
+          balance: 25,
+          liquidity_pool_id: pool2.id,
+          datetime: new Date("2022-05-19"),
+        },
+      ]);
+
+      expect(await totalValueLockedInPools([collaterToken1])).to.equal("10");
+    });
+
+    it("safely returns 0 if there are no pools for the specified collateral tokens", async () => {
+      const collaterToken1 = await createLiquidityCollateralToken("sRLY1");
+
+      expect(await totalValueLockedInPools([collaterToken1])).to.equal(0);
+    });
+
+    it("safely returns 0 if there are no recorded balances for any of the pools or tokens we are interested in", async () => {
+      expect(
+        await totalValueLockedInPools([collaterToken1, collaterToken2])
+      ).to.equal(0);
+    });
   });
 
-  it("can ignore balances for collateral tokens we don't care about ", async () => {
-    await knex<LiquidityPoolBalance>("liquidity_pool_balances").insert([
-      {
-        balance: 10,
-        liquidity_pool_id: pool1.id,
-        datetime: new Date("2022-05-20"),
-      },
-      {
-        balance: 5,
-        liquidity_pool_id: pool1.id,
-        datetime: new Date("2022-05-19"),
-      },
-      {
-        balance: 25,
-        liquidity_pool_id: pool2.id,
-        datetime: new Date("2022-05-19"),
-      },
-    ]);
+  describe("#valueLockedByDay", () => {
+    it("returns the sum of tbc balances by day for the given collateral tokens", async () => {
+      await knex<LiquidityPoolBalance>("liquidity_pool_balances").insert([
+        {
+          balance: 10,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-20"),
+        },
+        {
+          balance: 5,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-19"),
+        },
+        {
+          balance: 25,
+          liquidity_pool_id: pool2.id,
+          datetime: new Date("2022-05-19"),
+        },
+        {
+          balance: 35,
+          liquidity_pool_id: pool2.id,
+          datetime: new Date("2022-05-20"),
+        },
+      ]);
 
-    expect(await totalValueLockedInPools([collaterToken1])).to.equal("10");
-  });
+      expect(await valueLockedByDay([collaterToken1, collaterToken2])).to.eql([
+        { date: "2022-05-19T00:00:00.000Z", balance: 30 },
+        { date: "2022-05-20T00:00:00.000Z", balance: 45 },
+      ]);
+    });
+    it("can ignore balances for collateral tokens we don't care about ", async () => {
+      await knex<LiquidityPoolBalance>("liquidity_pool_balances").insert([
+        {
+          balance: 10,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-20"),
+        },
+        {
+          balance: 5,
+          liquidity_pool_id: pool1.id,
+          datetime: new Date("2022-05-19"),
+        },
+        {
+          balance: 25,
+          liquidity_pool_id: pool2.id,
+          datetime: new Date("2022-05-19"),
+        },
+        {
+          balance: 35,
+          liquidity_pool_id: pool2.id,
+          datetime: new Date("2022-05-20"),
+        },
+      ]);
 
-  it("safely returns 0 if there are no pools for the specified collateral tokens", async () => {
-    const collaterToken1 = await createLiquidityCollateralToken("sRLY1");
-
-    expect(await totalValueLockedInPools([collaterToken1])).to.equal(0);
-  });
-
-  it("safely returns 0 if there are no recorded balances for any of the pools or tokens we are interested in", async () => {
-    expect(
-      await totalValueLockedInPools([collaterToken1, collaterToken2])
-    ).to.equal(0);
+      expect(await valueLockedByDay([collaterToken1])).to.eql([
+        { date: "2022-05-19T00:00:00.000Z", balance: 5 },
+        { date: "2022-05-20T00:00:00.000Z", balance: 10 },
+      ]);
+    });
   });
 });

--- a/tests/computed_metrics/transaction_metrics.test.ts
+++ b/tests/computed_metrics/transaction_metrics.test.ts
@@ -2,111 +2,190 @@ import { expect } from "chai";
 import { getKnex } from "../../src/database";
 import { TrackedToken } from "../../src/knex-types/tracked_token";
 import { createAccount, createTrackedToken } from "../factories";
-import { totalTransactions } from "../../src/computed_metrics/transaction_metrics";
+import {
+  totalTransactions,
+  transactionsByDay,
+} from "../../src/computed_metrics/transaction_metrics";
+import { TrackedTokenAccount } from "../../src/knex-types/tracked_token_account";
 
 const knex = getKnex();
 
-describe("#totalTransactions", () => {
+describe("Transaction Computed Metrics", () => {
   let trackedToken: TrackedToken;
   beforeEach(async () => {
     trackedToken = await createTrackedToken("sRLY", "fake_address_1");
   });
 
-  it("returns the total count of transactions involving the given tracked tokens", async () => {
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken, new Date("2022-05-21"));
+  describe("#totalTransactions", () => {
+    it("returns the total count of transactions involving the given tracked tokens", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
 
-    await knex("tracked_token_account_transactions").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        transaction_hash: Uint8Array.from([1]),
-        transfer_in: true,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        transaction_hash: Uint8Array.from([2]),
-        transfer_in: false,
-      },
-    ]);
+      await knex("tracked_token_account_transactions").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([1]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          transaction_hash: Uint8Array.from([2]),
+          transfer_in: false,
+        },
+      ]);
 
-    expect(await totalTransactions([trackedToken])).to.equal("2");
+      expect(await totalTransactions([trackedToken])).to.equal(2);
+    });
+
+    it("supports combining transaction counts for multiple supplied tokens of interest", async () => {
+      const trackedToken2 = await createTrackedToken("Taki", "fake_address_2");
+
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken2,
+        new Date("2022-05-21")
+      );
+
+      await knex("tracked_token_account_transactions").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([1]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          transaction_hash: Uint8Array.from([2]),
+          transfer_in: false,
+        },
+      ]);
+
+      expect(await totalTransactions([trackedToken, trackedToken2])).to.equal(
+        2
+      );
+    });
+
+    it("ignores transactions for tokens we aren't interested in", async () => {
+      const trackedToken2 = await createTrackedToken("Taki", "fake_address_2");
+
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken2,
+        new Date("2022-05-21")
+      );
+
+      await knex("tracked_token_account_transactions").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([1]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          transaction_hash: Uint8Array.from([2]),
+          transfer_in: false,
+        },
+      ]);
+
+      expect(await totalTransactions([trackedToken])).to.equal(1);
+    });
+
+    it("supports filtering out transactions prior to a given start date", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
+
+      await knex("tracked_token_account_transactions").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([1]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          transaction_hash: Uint8Array.from([2]),
+          transfer_in: false,
+        },
+      ]);
+
+      expect(
+        await totalTransactions([trackedToken], {
+          startDate: new Date("2022-05-21"),
+        })
+      ).to.equal(1);
+    });
   });
 
-  it("supports combining transaction counts for multiple supplied tokens of interest", async () => {
-    const trackedToken2 = await createTrackedToken("Taki", "fake_address_2");
+  describe("transactionsByDay", () => {
+    it("returns the number of transactions by day for the tokens we asked about", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
 
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken2, new Date("2022-05-21"));
+      await knex("tracked_token_account_transactions").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([1]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([4]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-20"),
+          transaction_hash: Uint8Array.from([3]),
+          transfer_in: true,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          transaction_hash: Uint8Array.from([2]),
+          transfer_in: false,
+        },
+      ]);
 
-    await knex("tracked_token_account_transactions").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        transaction_hash: Uint8Array.from([1]),
-        transfer_in: true,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        transaction_hash: Uint8Array.from([2]),
-        transfer_in: false,
-      },
-    ]);
+      expect(await transactionsByDay([trackedToken])).to.eql([
+        { date: "2022-05-20T00:00:00.000Z", transactionCount: 3 },
+        { date: "2022-05-21T00:00:00.000Z", transactionCount: 1 },
+      ]);
+    });
 
-    expect(await totalTransactions([trackedToken, trackedToken2])).to.equal(
-      "2"
-    );
-  });
+    it("ignores transactions from tokens we don't care about", async () => {});
 
-  it("ignores transactions for tokens we aren't interested in", async () => {
-    const trackedToken2 = await createTrackedToken("Taki", "fake_address_2");
-
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken2, new Date("2022-05-21"));
-
-    await knex("tracked_token_account_transactions").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        transaction_hash: Uint8Array.from([1]),
-        transfer_in: true,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        transaction_hash: Uint8Array.from([2]),
-        transfer_in: false,
-      },
-    ]);
-
-    expect(await totalTransactions([trackedToken])).to.equal("1");
-  });
-
-  it("supports filtering out transactions prior to a given start date", async () => {
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken, new Date("2022-05-21"));
-
-    await knex("tracked_token_account_transactions").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        transaction_hash: Uint8Array.from([1]),
-        transfer_in: true,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        transaction_hash: Uint8Array.from([2]),
-        transfer_in: false,
-      },
-    ]);
-
-    expect(
-      await totalTransactions([trackedToken], {
-        startDate: new Date("2022-05-21"),
-      })
-    ).to.equal("1");
+    it("allows optionally setting how many days we want to return", async () => {});
   });
 });

--- a/tests/computed_metrics/wallet_metrics.test.ts
+++ b/tests/computed_metrics/wallet_metrics.test.ts
@@ -1,121 +1,234 @@
 import { expect } from "chai";
 import { getKnex } from "../../src/database";
 import { TrackedToken } from "../../src/knex-types/tracked_token";
-import { totalWallets } from "../../src/computed_metrics/wallet_metrics";
+import {
+  totalWallets,
+  totalWalletsByDay,
+} from "../../src/computed_metrics/wallet_metrics";
 import { createAccount, createTrackedToken } from "../factories";
 
 const knex = getKnex();
 
-describe("#totalWallets", () => {
+describe("Computed Wallet Metrics", () => {
   let trackedToken: TrackedToken;
   beforeEach(async () => {
     trackedToken = await createTrackedToken("sRLY", "fake_address_1");
   });
+  describe("#totalWallets", () => {
+    it("returns the total number of wallets that exist for the given minted Token", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
 
-  it("returns the total number of wallets that exist for the given minted Token", async () => {
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken, new Date("2022-05-21"));
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 0,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+      ]);
 
-    await knex("tracked_token_account_balances").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        approximate_minimum_balance: 0,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        approximate_minimum_balance: 10,
-      },
-    ]);
+      expect(await totalWallets([trackedToken])).to.equal("2");
+    });
 
-    expect(await totalWallets([trackedToken])).to.equal("2");
+    it("supports combining wallet counts for multiple supplied tokens of interest", async () => {
+      const trackedToken2 = await createTrackedToken("Taki", "fake_address_2");
+
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken2,
+        new Date("2022-05-21")
+      );
+
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 10,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+      ]);
+
+      expect(await totalWallets([trackedToken, trackedToken2])).to.equal("2");
+    });
+
+    it("filters out 0 balance wallets when passed function option flag", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
+
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 0,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+      ]);
+
+      expect(
+        await totalWallets([trackedToken], {
+          removeEmptyWallets: true,
+        })
+      ).to.equal("1");
+    });
+
+    it("does not include the same wallet address more than once per token type", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 10,
+        },
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+      ]);
+
+      expect(await totalWallets([trackedToken])).to.equal("1");
+    });
+
+    it("supports removing balances that existed prior to a given optional start date", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
+
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 10,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+      ]);
+
+      expect(
+        await totalWallets([trackedToken], {
+          startDate: new Date("2022-05-21"),
+        })
+      ).to.equal("1");
+    });
   });
 
-  it("supports combining wallet counts for multiple supplied tokens of interest", async () => {
-    const trackedToken2 = await createTrackedToken("Taki", "fake_address_2");
+  describe("#totalWalletsByDay", () => {
+    it("returns the total number of unique wallets by day for the given tracked tokens", async () => {
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(
+        trackedToken,
+        new Date("2022-05-21")
+      );
 
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken2, new Date("2022-05-21"));
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 0,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 0,
+        },
+      ]);
 
-    await knex("tracked_token_account_balances").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        approximate_minimum_balance: 10,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        approximate_minimum_balance: 10,
-      },
-    ]);
+      expect(await totalWalletsByDay([trackedToken])).to.eql([
+        {
+          date: "2022-05-20T00:00:00.000Z",
+          walletCount: 1,
+        },
+        {
+          date: "2022-05-21T00:00:00.000Z",
+          walletCount: 2,
+        },
+      ]);
+    });
 
-    expect(await totalWallets([trackedToken, trackedToken2])).to.equal("2");
-  });
+    it("can ignore wallets for tokens we aren't interested in", async () => {
+      const token2 = await createTrackedToken("foobar", "fake_address_2");
+      const account1 = await createAccount(
+        trackedToken,
+        new Date("2022-05-20")
+      );
+      const account2 = await createAccount(token2, new Date("2022-05-21"));
 
-  it("filters out 0 balance wallets when passed function option flag", async () => {
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken, new Date("2022-05-21"));
+      await knex("tracked_token_account_balances").insert([
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-20"),
+          approximate_minimum_balance: 0,
+        },
+        {
+          tracked_token_account_id: account2.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 10,
+        },
+        {
+          tracked_token_account_id: account1.id,
+          datetime: new Date("2022-05-21"),
+          approximate_minimum_balance: 0,
+        },
+      ]);
 
-    await knex("tracked_token_account_balances").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        approximate_minimum_balance: 0,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        approximate_minimum_balance: 10,
-      },
-    ]);
-
-    expect(
-      await totalWallets([trackedToken], {
-        removeEmptyWallets: true,
-      })
-    ).to.equal("1");
-  });
-
-  it("does not include the same wallet address more than once per token type", async () => {
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-
-    await knex("tracked_token_account_balances").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        approximate_minimum_balance: 10,
-      },
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-21"),
-        approximate_minimum_balance: 10,
-      },
-    ]);
-
-    expect(await totalWallets([trackedToken])).to.equal("1");
-  });
-
-  it("supports removing balances that existed prior to a given optional start date", async () => {
-    const account1 = await createAccount(trackedToken, new Date("2022-05-20"));
-    const account2 = await createAccount(trackedToken, new Date("2022-05-21"));
-
-    await knex("tracked_token_account_balances").insert([
-      {
-        tracked_token_account_id: account1.id,
-        datetime: new Date("2022-05-20"),
-        approximate_minimum_balance: 10,
-      },
-      {
-        tracked_token_account_id: account2.id,
-        datetime: new Date("2022-05-21"),
-        approximate_minimum_balance: 10,
-      },
-    ]);
-
-    expect(
-      await totalWallets([trackedToken], { startDate: new Date("2022-05-21") })
-    ).to.equal("1");
+      expect(await totalWalletsByDay([trackedToken])).to.eql([
+        {
+          date: "2022-05-20T00:00:00.000Z",
+          walletCount: 1,
+        },
+        {
+          date: "2022-05-21T00:00:00.000Z",
+          walletCount: 1,
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
- Add ability to compute TVL by day for a given list of collateral tokens
- Add logic to count transactions by day for relevant tracked tokens
- Add logic to compute number of wallets by day
